### PR TITLE
Use signal to make test more robust

### DIFF
--- a/spyder_line_profiler/widgets/lineprofiler.py
+++ b/spyder_line_profiler/widgets/lineprofiler.py
@@ -85,6 +85,7 @@ class LineProfilerWidget(QWidget):
     DATAPATH = get_conf_path('lineprofiler.results')
     VERSION = '0.0.1'
     redirect_stdio = Signal(bool)
+    sig_finished = Signal()
 
     def __init__(self, parent):
         QWidget.__init__(self, parent)
@@ -314,6 +315,7 @@ class LineProfilerWidget(QWidget):
         # FIXME: figure out if show_data should be called here or
         #        as a signal from the combobox
         self.show_data(justanalyzed=True)
+        self.sig_finished.emit()
 
     def kill_if_running(self):
         if self.process is not None:

--- a/spyder_line_profiler/widgets/tests/test_lineprofiler.py
+++ b/spyder_line_profiler/widgets/tests/test_lineprofiler.py
@@ -50,8 +50,8 @@ def test_profile_and_display_results(qtbot, tmpdir, monkeypatch):
 
     widget = LineProfilerWidget(None)
     qtbot.addWidget(widget)
-    widget.analyze(testfilename)
-    qtbot.wait(2000) # wait for tests to run
+    with qtbot.waitSignal(widget.sig_finished, timeout=10000, raising=True):
+        widget.analyze(testfilename)
 
     MockQMessageBox.assert_not_called()
     dt = widget.datatree


### PR DESCRIPTION
Introduce a signal in the widget which is emitted when the profiling has finished, and use that signal in the test instead of a 2s delay. I hope this prevents random test failures.