### PR TITLE
PR: Add CONF_DEFAULTS

### DIFF
--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,4 +1,4 @@
-coveralls
+coveralls >=1.8
 mock
 pytest
 pytest-cov

--- a/spyder_line_profiler/lineprofiler.py
+++ b/spyder_line_profiler/lineprofiler.py
@@ -73,6 +73,7 @@ class LineProfiler(SpyderPluginWidget):
     Line profiler.
     """
     CONF_SECTION = 'lineprofiler'
+    CONF_DEFAULTS = [(CONF_SECTION, {'use_colors': True})]
     CONFIGWIDGET_CLASS = LineProfilerConfigPage
     edit_goto = Signal(str, int, str)
 


### PR DESCRIPTION
With Spyder 4, defaults for all config options need to be listed; compare spyder-ide/spyder-notebook#225.

Fixes #39