### PR TITLE
Remove import of add_pathlist_to_PYTHONPATH()

### DIFF
--- a/spyder_line_profiler/spyder/widgets.py
+++ b/spyder_line_profiler/spyder/widgets.py
@@ -65,39 +65,6 @@ def is_lineprofiler_installed():
             and programs.find_program('kernprof') is not None)
 
 
-def add_pathlist_to_PYTHONPATH(env, pathlist, drop_env=True):
-    """
-    Add a PYTHONPATH entry to a list of environment variables.
-    This allows to extend the environment of an external process
-    created with QProcess with our additions to PYTHONPATH.
-    Parameters
-    ----------
-    env: list
-        List of environment variables in the format of
-        QProcessEnvironment.
-    pathlist: list
-        List of paths to add to PYTHONPATH
-    drop_env: bool
-        Whether to drop PYTHONPATH previously found in the environment.
-    """
-    # PyQt API 1/2 compatibility-related tests:
-    assert isinstance(env, list)
-    # Next line commented out temporarily
-    # assert all([is_text_string(path) for path in env])
-
-    pypath = "PYTHONPATH"
-    pathstr = os.pathsep.join(pathlist)
-    if not drop_env:
-        for index, var in enumerate(env[:]):
-            if var.startswith(pypath + '='):
-                env[index] = var.replace(
-                    pypath + '=',
-                    pypath + '=' + pathstr + os.pathsep
-                )
-    else:
-        env.append(pypath + '=' + pathstr)
-        
-
 class TreeWidgetItem(QTreeWidgetItem):
     """
     An extension of QTreeWidgetItem that replaces the sorting behaviour
@@ -445,7 +412,7 @@ class SpyderLineProfilerWidget(PluginMainWidget):
         if pythonpath is not None:
             env = [to_text_string(_pth)
                    for _pth in self.process.systemEnvironment()]
-            add_pathlist_to_PYTHONPATH(env, pythonpath)
+            env.append(f'PYTHONPATH={pythonpath}{os.pathsep}')
             processEnvironment = QProcessEnvironment()
             for envItem in env:
                 envName, separator, envValue = envItem.partition('=')

--- a/spyder_line_profiler/spyder/widgets.py
+++ b/spyder_line_profiler/spyder/widgets.py
@@ -26,7 +26,6 @@ from qtpy.QtWidgets import (QMessageBox, QVBoxLayout, QLabel,
 from qtpy.compat import getopenfilename, getsavefilename
 
 # Spyder imports
-
 from spyder.api.config.decorators import on_conf_change
 from spyder.api.translations import get_translation
 from spyder.config.base import get_conf_path
@@ -37,6 +36,9 @@ from spyder.utils import programs
 from spyder.utils.misc import getcwd_or_home
 from spyder.plugins.run.widgets import get_run_configuration
 from spyder.py3compat import to_text_string, pickle
+
+# Local imports
+from spyder_line_profiler.spyder.config import CONF_SECTION
 
 # Localization
 _ = get_translation("spyder")
@@ -136,8 +138,10 @@ class SpyderLineProfilerWidgetInformationToolbarItems:
 class SpyderLineProfilerWidget(PluginMainWidget):
 
     # PluginMainWidget class constants
+    CONF_SECTION = CONF_SECTION
     DATAPATH = get_conf_path('lineprofiler.results')
     VERSION = '0.0.1'
+
     redirect_stdio = Signal(bool)
     sig_finished = Signal()
     # Signals
@@ -412,7 +416,7 @@ class SpyderLineProfilerWidget(PluginMainWidget):
         if pythonpath is not None:
             env = [to_text_string(_pth)
                    for _pth in self.process.systemEnvironment()]
-            env.append(f'PYTHONPATH={pythonpath}{os.pathsep}')
+            env.append(f'PYTHONPATH={pythonpath}')
             processEnvironment = QProcessEnvironment()
             for envItem in env:
                 envName, separator, envValue = envItem.partition('=')

--- a/spyder_line_profiler/spyder/widgets.py
+++ b/spyder_line_profiler/spyder/widgets.py
@@ -34,7 +34,7 @@ from spyder.plugins.variableexplorer.widgets.texteditor import TextEditor
 from spyder.api.widgets.main_widget import PluginMainWidget
 from spyder.widgets.comboboxes import PythonModulesComboBox
 from spyder.utils import programs
-from spyder.utils.misc import add_pathlist_to_PYTHONPATH, getcwd_or_home
+from spyder.utils.misc import getcwd_or_home
 from spyder.plugins.run.widgets import get_run_configuration
 from spyder.py3compat import to_text_string, pickle
 
@@ -64,6 +64,39 @@ def is_lineprofiler_installed():
     return (programs.is_module_installed('line_profiler')
             and programs.find_program('kernprof') is not None)
 
+
+def add_pathlist_to_PYTHONPATH(env, pathlist, drop_env=True):
+    """
+    Add a PYTHONPATH entry to a list of environment variables.
+    This allows to extend the environment of an external process
+    created with QProcess with our additions to PYTHONPATH.
+    Parameters
+    ----------
+    env: list
+        List of environment variables in the format of
+        QProcessEnvironment.
+    pathlist: list
+        List of paths to add to PYTHONPATH
+    drop_env: bool
+        Whether to drop PYTHONPATH previously found in the environment.
+    """
+    # PyQt API 1/2 compatibility-related tests:
+    assert isinstance(env, list)
+    # Next line commented out temporarily
+    # assert all([is_text_string(path) for path in env])
+
+    pypath = "PYTHONPATH"
+    pathstr = os.pathsep.join(pathlist)
+    if not drop_env:
+        for index, var in enumerate(env[:]):
+            if var.startswith(pypath + '='):
+                env[index] = var.replace(
+                    pypath + '=',
+                    pypath + '=' + pathstr + os.pathsep
+                )
+    else:
+        env.append(pypath + '=' + pathstr)
+        
 
 class TreeWidgetItem(QTreeWidgetItem):
     """


### PR DESCRIPTION
The function add_pathlist_to_PYTHONPATH() was removed in Spyder 5.3.2 which breaks the plugin. This PR puts the relevant code (which is just one line) in the plugin.

Actually, I am not sure why the code is in, but it should do the same now as before with Spyder 5.3.1.

Fixes #65 