### PR TITLE
PR: Make copyright headers consistent

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Description of Changes
+
+<!--- Explain what you've done and why --->
+
+
+### Affirmation
+
+By submitting this Pull Request or typing my (user)name below,
+I affirm the [Developer Certificate of Origin](https://developercertificate.org)
+with respect to all commits and content included in this PR,
+and understand I am releasing the same under Spyder's MIT (Expat) license.
+
+<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
+I certify the above statement is true and correct:
+
+<!--- Thanks for your help making Spyder better for everyone! --->

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,20 +1,12 @@
-Maintainer
-==========
+# Authors
 
-The [Spyder Development Team](https://github.com/orgs/spyder-ide/teams/core-developers)
+## Original author
 
-Main Authors
-============
+* Joseph Martinot-Lagarde ([@Nodd](http://github.com/Nodd))
 
-Joseph Martinot-Lagarde ([@Nodd](http://github.com/Nodd))
 
-Code Contributors
-=================
+## Current maintainers
 
-Christer van der Meeren ([@cmeeren](http://github.com/cmeeren))
-
-Gonzalo Peña-Castellanos ([@goanpeca](http://github.com/goanpeca))
-
-Steven Silvester ([@blink1073](http://github.com/blink1073))
-
-Simon Kern [@skjerns](http://github.com/skjerns))
+* Jitse Niesen ([@jitseniesen](https://github.com/jitseniesen))
+* The [Spyder Development Team](https://github.com/spyder-ide)
+* The [spyder-line-profiler Contributors](https://github.com/spyder-ide/spyder-line-profiler/graphs/contributors)

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright © 2022 Spyder Project Contributors
-# Licensed under the terms of the MIT License
-# (see LICENSE.txt for details)
+# -----------------------------------------------------------------------------
+# Copyright (c) 2015- Spyder Project Contributors
+#
+# Released under the terms of the MIT License
+# (see LICENSE.txt in the project root directory for details)
+# -----------------------------------------------------------------------------
 
 """
 Setup script for spyder_line_profiler

--- a/spyder_line_profiler/__init__.py
+++ b/spyder_line_profiler/__init__.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
-# ----------------------------------------------------------------------------
-# Copyright © 2022, Spyder Line Profiler contributors
 #
-# Licensed under the terms of the MIT license
-# ----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
+# Copyright (c) 2013- Spyder Project Contributors
+#
+# Released under the terms of the MIT License
+# (see LICENSE.txt in the project root directory for details)
+# -----------------------------------------------------------------------------
+
 """
 Spyder Line Profiler.
 """
 
 __version__ = "0.4.0.dev0"
-
-
-

--- a/spyder_line_profiler/example/profiling_test_script.py
+++ b/spyder_line_profiler/example/profiling_test_script.py
@@ -1,10 +1,12 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-u"""
-:author: Joseph Martinot-Lagarde
-
-Created on Sat Jan 19 14:57:57 2013
-"""
+#
+# -----------------------------------------------------------------------------
+# Copyright (c) 2013- Spyder Project Contributors
+#
+# Released under the terms of the MIT License
+# (see LICENSE.txt in the project root directory for details)
+# -----------------------------------------------------------------------------
 
 from __future__ import (
     print_function, division, unicode_literals, absolute_import)

--- a/spyder_line_profiler/example/subdir/profiling_test_script2.py
+++ b/spyder_line_profiler/example/subdir/profiling_test_script2.py
@@ -1,10 +1,12 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-u"""
-:author: Joseph Martinot-Lagarde
-
-Created on Sat Jan 19 14:57:57 2013
-"""
+#
+# -----------------------------------------------------------------------------
+# Copyright (c) 2013- Spyder Project Contributors
+#
+# Released under the terms of the MIT License
+# (see LICENSE.txt in the project root directory for details)
+# -----------------------------------------------------------------------------
 
 from __future__ import (
     print_function, division, unicode_literals, absolute_import)

--- a/spyder_line_profiler/spyder/__init__.py
+++ b/spyder_line_profiler/spyder/__init__.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
-# ----------------------------------------------------------------------------
-# Copyright © 2022, Spyder Line Profiler contributors
 #
-# Licensed under the terms of the MIT license
-# ----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
+# Copyright (c) 2013- Spyder Project Contributors
+#
+# Released under the terms of the MIT License
+# (see LICENSE.txt in the project root directory for details)
+# -----------------------------------------------------------------------------"""
+
 """
 Spyder Line Profiler
 """

--- a/spyder_line_profiler/spyder/config.py
+++ b/spyder_line_profiler/spyder/config.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright © 2022-, Spyder Line Profiler contributors
-# Licensed under the terms of the MIT License
-# (see spyder/__init__.py for details)
+# -----------------------------------------------------------------------------
+# Copyright (c) 2022- Spyder Project Contributors
+#
+# Released under the terms of the MIT License
+# (see LICENSE.txt in the project root directory for details)
+# -----------------------------------------------------------------------------
 
 """Spyder line-profiler default configuration."""
 

--- a/spyder_line_profiler/spyder/confpage.py
+++ b/spyder_line_profiler/spyder/confpage.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
-# ----------------------------------------------------------------------------
-# Copyright © 2021, Spyder Line Profiler contributors
 #
-# Licensed under the terms of the MIT license
-# ----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
+# Copyright (c) 2013- Spyder Project Contributors
+#
+# Released under the terms of the MIT License
+# (see LICENSE.txt in the project root directory for details)
+# -----------------------------------------------------------------------------
 
 """
 Spyder Line Profiler 5 Preferences Page.

--- a/spyder_line_profiler/spyder/plugin.py
+++ b/spyder_line_profiler/spyder/plugin.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
-# ----------------------------------------------------------------------------
-# Copyright © 2021, Spyder Line Profiler contributors
 #
-# Licensed under the terms of the MIT license
-# ----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
+# Copyright (c) 2013- Spyder Project Contributors
+#
+# Released under the terms of the MIT License
+# (see LICENSE.txt in the project root directory for details)
+# -----------------------------------------------------------------------------
 
 """
 Spyder Line Profiler Plugin.

--- a/spyder_line_profiler/spyder/widgets.py
+++ b/spyder_line_profiler/spyder/widgets.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
-# ----------------------------------------------------------------------------
-# Copyright © 2021, Spyder Line Profiler contributors
 #
-# Licensed under the terms of the MIT license
-# ----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
+# Copyright (c) 2013- Spyder Project Contributors
+#
+# Released under the terms of the MIT License
+# (see LICENSE.txt in the project root directory for details)
+# -----------------------------------------------------------------------------
 """
 Spyder Line Profiler Main Widget.
 """

--- a/spyder_line_profiler/tests/test_lineprofiler.py
+++ b/spyder_line_profiler/tests/test_lineprofiler.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright © 2017 Spyder Project Contributors
-# Licensed under the terms of the MIT License
-# (see LICENSE.txt for details)
+# -----------------------------------------------------------------------------
+# Copyright (c) 2017- Spyder Project Contributors
+#
+# Released under the terms of the MIT License
+# (see LICENSE.txt in the project root directory for details)
+# -----------------------------------------------------------------------------
 
 """Tests for lineprofiler.py."""
 


### PR DESCRIPTION
This PR changes the copyright headers so that they are consistent in how they designate the copyright holder ("Spyder Project Contributors"). This is the formulation suggested in https://github.com/spyder-ide/governance-and-guidelines/blob/main/license_guidelines.md . Also change the file AUTHORS.md and add a PR template following the same guidelines.

Fixes #74 