### PR TITLE
PR: Use static and classmethods for plugin get_description and get_icon in order to work with Spyder 6a2

### DIFF
--- a/spyder_line_profiler/spyder/plugin.py
+++ b/spyder_line_profiler/spyder/plugin.py
@@ -62,11 +62,13 @@ class SpyderLineProfiler(SpyderDockablePlugin, RunExecutor):
     @staticmethod
     def get_name():
         return _("Line Profiler")
-
-    def get_description(self):
+    
+    @staticmethod
+    def get_description():
         return _("Line profiler display for Spyder")
-
-    def get_icon(self):
+    
+    @classmethod
+    def get_icon(cls):
         return qta.icon('mdi.speedometer', color=ima.MAIN_FG_COLOR)
 
     def on_initialize(self):


### PR DESCRIPTION
## Description of Changes
This PR sets the `get_description` and `get_icon` methods in the plugin class to static and classmethod, following the `SpyderPluginV2` in `spyder.api.plugins` for Spyder 6.

Fixes #86 

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: @rhkarls

<!--- Thanks for your help making Spyder better for everyone! --->
