### PR TITLE
Fix go-to-line when clicking entries

### DIFF
--- a/spyder_line_profiler/spyder/plugin.py
+++ b/spyder_line_profiler/spyder/plugin.py
@@ -107,6 +107,11 @@ class SpyderLineProfiler(SpyderDockablePlugin, RunExecutor):
                     "section": RunMenuSections.RunInExecutors
                 }
             )
+    @on_plugin_available(plugin=Plugins.Editor)
+    def on_editor_available(self):
+        widget = self.get_widget()
+        editor = self.get_plugin(Plugins.Editor)
+        widget.sig_edit_goto_requested.connect(editor.load)
 
     @on_plugin_available(plugin=Plugins.Preferences)
     def on_preferences_available(self):
@@ -125,6 +130,12 @@ class SpyderLineProfiler(SpyderDockablePlugin, RunExecutor):
     def on_preferences_teardown(self):
         preferences = self.get_plugin(Plugins.Preferences)
         preferences.deregister_plugin_preferences(self)
+
+    @on_plugin_teardown(plugin=Plugins.Editor)
+    def on_editor_teardown(self):
+        widget = self.get_widget()
+        editor = self.get_plugin(Plugins.Editor)
+        widget.sig_edit_goto_requested.disconnect(editor.load)
 
     def check_compatibility(self):
         valid = True


### PR DESCRIPTION
## Description of Changes
Fix go-to-line (focus code in editor) when clicking entries in the results table.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

I certify the above statement is true and correct:

rear1019