### PR TITLE
Fix runtime dependency check

### DIFF
--- a/spyder_line_profiler/spyder/widgets.py
+++ b/spyder_line_profiler/spyder/widgets.py
@@ -76,7 +76,7 @@ def is_lineprofiler_installed():
     Check if the program and the library for line_profiler is installed.
     """
     return (programs.is_module_installed('line_profiler')
-            and programs.find_program('kernprof') is not None)
+            and programs.is_module_installed('kernprof'))
 
 
 class TreeWidgetItem(QTreeWidgetItem):


### PR DESCRIPTION
## Description of Changes

Since commit https://github.com/spyder-ide/spyder-line-profiler/commit/c5bf915ef0b0d7a577093c9a4ff21d61d2b62506 the profiler is invoked using `python -m
kerprof`. The executable `kernprof` is not used anymore. Adapt runtime dependency check accordingly.

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:

rear1019
<!--- Thanks for your help making Spyder better for everyone! --->
