### PR TITLE
PR: Drop Python 3.8 and Python 3.9

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,8 +14,11 @@ jobs:
       fail-fast: false
       matrix:
         OS: ['ubuntu', 'macos', 'windows']
-        PYTHON_VERSION: ['3.9', '3.10', '3.11']
+        PYTHON_VERSION: ['3.10', '3.11', '3.12']
         SPYDER_SOURCE: ['conda', 'git']
+        exclude:
+          - OS: ['macos', 'windows']
+            PYTHON_VERSION: ['3.11']
     name: ${{ matrix.OS }} py${{ matrix.PYTHON_VERSION }} spyder-from-${{ matrix.SPYDER_SOURCE }}
     runs-on: ${{ matrix.OS }}-latest
     env:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -39,6 +39,7 @@ jobs:
         with:
            miniforge-version: latest
            auto-update-conda: true
+           conda-remove-defaults: "true"
            python-version: ${{ matrix.PYTHON_VERSION }}
       - name: Checkout Spyder from git
         if: matrix.SPYDER_SOURCE == 'git'

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
     install_requires=REQUIREMENTS,
     url='https://github.com/spyder-ide/spyder-line-profiler',
     license='MIT',
-    python_requires='>= 3.8',
+    python_requires='>= 3.10',
     entry_points={
         "spyder.plugins": [
             "spyder_line_profiler = spyder_line_profiler.spyder.plugin:SpyderLineProfiler"
@@ -89,8 +89,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',


### PR DESCRIPTION
## Description of Changes

Python 3.8 and 3.9 are no longer available on conda-forge for testing, so we increase our required version to Python 3.10. <s>No other changes are necessary for Spyder 6.1 as far as I can see.</s>

Partial fix for #101
<!--- Explain what you've done and why --->


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under Spyder's MIT (Expat) license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct:
Jitse Niesen

<!--- Thanks for your help making Spyder better for everyone! --->
